### PR TITLE
V3.0 road commerce & burgher fix

### DIFF
--- a/MEIOUandTaxes1/common/scripted_effects/SYS-API.txt
+++ b/MEIOUandTaxes1/common/scripted_effects/SYS-API.txt
@@ -6024,6 +6024,9 @@ Modi_ElitePromotionDemotion_Province = {
 		harbour_infrastructure_5 = { change_key = { lhs = Modi_IdealBurgherSizePerc_Multi value = 0.10 } }
 		harbour_infrastructure_6 = { change_key = { lhs = Modi_IdealBurgherSizePerc_Multi value = 0.125 } }
 		harbour_infrastructure_7 = { change_key = { lhs = Modi_IdealBurgherSizePerc_Multi value = 0.15 } }
+	}
+	trigger_switch = {
+		on_trigger = has_building
 		road_network = { change_key = { lhs = Modi_IdealBurgherSizePerc_Multi value = 0.01 } }
 		paved_road_network = { change_key = { lhs = Modi_IdealBurgherSizePerc_Multi value = 0.025 } }
 		highway_network = { change_key = { lhs = Modi_IdealBurgherSizePerc_Multi value = 0.04 } }

--- a/MEIOUandTaxes1/common/scripted_effects/SYS-API.txt
+++ b/MEIOUandTaxes1/common/scripted_effects/SYS-API.txt
@@ -2450,6 +2450,9 @@ Modi_ProdProvince = {
 		harbour_infrastructure_5 = { change_key = { lhs = Modi_CommerceNatural value = 0.20 } }
 		harbour_infrastructure_6 = { change_key = { lhs = Modi_CommerceNatural value = 0.25 } }
 		harbour_infrastructure_7 = { change_key = { lhs = Modi_CommerceNatural value = 0.30 } }
+	}
+	trigger_switch = {
+		on_trigger = has_building
 		road_network = { change_key = { lhs = Modi_CommerceNatural value = 0.025 } }
 		paved_road_network = { change_key = { lhs = Modi_CommerceNatural value = 0.05 } }
 		highway_network = { change_key = { lhs = Modi_CommerceNatural value = 0.075 } }


### PR DESCRIPTION
Both commerce and ideal burgher size boosts from roads were busted when harborages were present due to a combined `trigger_switch`. This corrects both of them