### PR TITLE
Bugfixes and Optimizations (syntax fix, decision optimization, tax relief, capitol maintenance)

### DIFF
--- a/MEIOUandTaxes1/common/scripted_effects/SYS-Infra.txt
+++ b/MEIOUandTaxes1/common/scripted_effects/SYS-Infra.txt
@@ -1952,7 +1952,19 @@ Infra_SetSpendInfra = {
 			limit = {
 				OR = {
 					has_province_flag = Infra_$type$100
-					[[StateFunded] always = $StateFunded$ ]
+					#[[StateFunded] always = $StateFunded$ ]
+					
+					# BrutusY: Here should be StateBased rather than the old StateFunded
+					# However, since only Capitol is StateBased
+					# This code condition alone would make AI maintain unnecessary Capitol Buildings
+					AND = {
+						always = $StateBased$
+						is_capital = yes
+						# This condition ensures that only the capital's Capitol building will be maintained
+						# Hopefully, AI would not maintain a bunch of idle Capitols
+						# After conquering a bunch of small neighbours
+					}
+
 				}
 			}
 			change_key = { lhs = Infra_StateSpend which = Infra_$type$Spend }

--- a/MEIOUandTaxes1/common/scripted_effects/SYS-ProvInteraction.txt
+++ b/MEIOUandTaxes1/common/scripted_effects/SYS-ProvInteraction.txt
@@ -553,7 +553,9 @@ BU_FightCrptRevitalise = {
 BU_TaxRelief = {
     add_country_modifier = {
         name = BU_TaxRelief
-        duration = 1095 # 3 years
+		# BrutusY: slightly decreasing duration to make sure it hits exactly three tax calculation
+		# This is more inline with our intuitive understanding of 3-year tax relief
+        duration = 1000 # 3 years
     }
 }
 BU_DistributeGrainMinor = {

--- a/MEIOUandTaxes1/common/scripted_effects/SYS-Prov_Misc.txt
+++ b/MEIOUandTaxes1/common/scripted_effects/SYS-Prov_Misc.txt
@@ -3331,6 +3331,23 @@ Prov_DoTaxBU = {
 		}
 		Tax_ResetTax = yes
 	}
+	# BrutusY: delay applying BU_TaxRelief modifier to here
+	# This allows the timed modifier to be in sync with tax cycle
+	# Using country_flag BU_TaxReliefStarted to set the modifier
+	if = {
+		limit = {
+			owner = {
+				has_country_flag = BU_TaxReliefStarted 
+			}
+		}
+		owner = {
+			clr_country_flag = BU_TaxReliefStarted
+			BU_TaxRelief = yes
+			# Maybe adding a event here indicating that Tax Relief is in effect
+			# Description would be how your subjects are relishing in the new tax relief measure
+		}
+	}
+	# End of delayed applying BU_TaxRelief
 	if = {
 		limit = {
 			owner = { NOT = { has_country_modifier = BU_TaxRelief } }

--- a/MEIOUandTaxes1/decisions/RASE-Japan.txt
+++ b/MEIOUandTaxes1/decisions/RASE-Japan.txt
@@ -381,8 +381,13 @@ country_decisions = {
 			}
 		}
 		allow = {
-			NOT = { any_known_country = { has_country_flag = chugoku_tandai } }
-			check_variable = { which = Demesne_in_Shogunate value = 3 }
+			NOT = { 
+                overlord ={
+                    any_subject_country = {
+                        has_country_flag = chugoku_tandai
+                    }
+                }
+            }			check_variable = { which = Demesne_in_Shogunate value = 3 }
 			adm_power = 250
 			dip_power = 250
 		}
@@ -420,8 +425,13 @@ country_decisions = {
 			area = shikoku_area
 		}
 		allow = {
-			NOT = { any_known_country = { has_country_flag = shikoku_tandai } }
-			check_variable = { which = Demesne_in_Shogunate value = 3 }
+			NOT = { 
+                overlord ={
+                    any_subject_country = {
+                        has_country_flag = shikoku_tandai
+                    }
+                }
+            }			check_variable = { which = Demesne_in_Shogunate value = 3 }
 			adm_power = 250
 			dip_power = 250
 		}
@@ -456,8 +466,13 @@ country_decisions = {
 			NOT = { has_country_modifier = promotion_denied }
 		}
 		allow = {
-			NOT = { any_known_country = { has_country_flag = uo_tandai } }
-			check_variable = { which = Demesne_in_Shogunate value = 3 }
+			NOT = { 
+                overlord ={
+                    any_subject_country = {
+                        has_country_flag = ou_tandai
+                    }
+                }
+            }			check_variable = { which = Demesne_in_Shogunate value = 3 }
 			adm_power = 250
 			dip_power = 250
 		}

--- a/MEIOUandTaxes1/events/DG-04-Hussites.txt
+++ b/MEIOUandTaxes1/events/DG-04-Hussites.txt
@@ -118,7 +118,10 @@ province_event = {
 			clr_global_flag = DG_Western_Schism_Timer
 		}
 		log = "DG:[GetYear]:[This.aab.GetValue]:Hussite:Birth:[This.GetName]:[This.Owner.GetName]"
-		add_reform_desire = 0.00025
+		owner = {
+			add_reform_desire = 0.00025
+		}
+		
 		hidden_effect = {
 			set_province_flag = hus_craddle
 			save_global_event_target_as = hus_origins

--- a/MEIOUandTaxes1/events/DG-06-Lollards.txt
+++ b/MEIOUandTaxes1/events/DG-06-Lollards.txt
@@ -33,7 +33,10 @@ province_event = {
 		enable_religion = lollard
 		hidden_effect = { set_global_flag = DG_Wycliffite_Spawn }
 		log = "DG:[GetYear]:[This.aab.GetValue]:Wycliffite:Birth:[This.GetName]:[This.Owner.GetName]"
-		add_reform_desire = 0.00025
+		owner = {
+			add_reform_desire = 0.00025
+		}
+		
 		hidden_effect = {
 			set_province_flag = lol_craddle
 			save_global_event_target_as = lol_origins

--- a/MEIOUandTaxes1/events/E-ChinaCollapse.txt
+++ b/MEIOUandTaxes1/events/E-ChinaCollapse.txt
@@ -756,7 +756,11 @@ country_event = {
 			remove_country_modifier = BU_GrainDoleMinor
 			remove_country_modifier = BU_GrainDoleMajor
 			remove_country_modifier = BU_GrainDoleFull
+			# BrutusY: Should remove existing TaxRelief as well
+			clr_country_flag = BU_TaxReliefStarted
+			remove_country_modifier = BU_TaxRelief
 		}
+		# BrutusY: Makes sense to make this TaxRelief go into effect immediately
 		BU_TaxRelief = yes
 		BU_DistributeGrainFull = yes
 		add_adm_power = -100

--- a/MEIOUandTaxes1/events/SYS-Prov_UI.txt
+++ b/MEIOUandTaxes1/events/SYS-Prov_UI.txt
@@ -7969,7 +7969,7 @@ country_event = {
 			factor = 3
 		}
 	}
-
+	# "Enact Land Reform"
 	option = {
 		name = BU_LandGrant_P_t
 		trigger = {
@@ -8001,7 +8001,7 @@ country_event = {
 			factor = 0
 		}
 	}
-
+	# "Provide Proterty Grant"
 	option = {
 		name = BU_LandGrant_R_t
 		trigger = {
@@ -8031,16 +8031,28 @@ country_event = {
 			factor = 0
 		}
 	}
-
+	# "Provide Temporary Tax Relief"
 	option = {
 		name = BU_TaxRelief_t
 		trigger = {
-			NOT = { has_country_modifier = BU_TaxRelief }
+			NOT = { 
+				has_country_modifier = BU_TaxRelief 
+				# Check TaxRelief that's not in effect yet
+				has_country_flag = BU_TaxReliefStarted
+			}
 		}
 		log ="SYS-Politics:[GetYear]:[This.GetName]:Tax Relief:Commoners:+:[This.GovernmentName]"
 
 		set_country_flag = ProvUI_Action
-		BU_TaxRelief = yes
+
+		# BU_TaxRelief = yes
+		# BrutusY: Instead of immediately applying the timed modifier
+		# We will first set the BU_TaxReliefStarted flag
+		# In the province tax calculation, the flag will first be checked
+		# So that the timed modifier is applied in sync with tax cycle
+		
+		set_country_flag = BU_TaxReliefStarted
+		
 		Stab_Add50Percent = yes
 		add_adm_power = -20
 		Pol_ChangeRelationsEliteStateTooltip = { val=10 }	
@@ -8089,7 +8101,7 @@ country_event = {
 			}
 		}
 	}
-
+	# "Provide Grain for the Commoners"
 	option = {
 		name = BU_Grain_t
 		trigger = {
@@ -8155,7 +8167,7 @@ country_event = {
 			}
 		}
 	}
-
+	# "Expropriate Land and Property"
 	option = {
 		name = BU_LandExpropriate_t
 		trigger = {

--- a/MEIOUandTaxes1/localisation/SYS-Interactions_l_english.yml
+++ b/MEIOUandTaxes1/localisation/SYS-Interactions_l_english.yml
@@ -370,7 +370,7 @@
  BU_Advisor_effect: "£estate_bureaucracy_icon_small£ §G+0.25%§! Yearly §MState Reach§! for §Y5§! years"
  BU_Advisor_expl: "---------------\nPrepare the bureaucracy for far-reaching reforms, employing a statesman from the Bureaucratic faction and gathering support among the bureaucrats for a 5 year reform plan."
  BU_TaxRelief_t: "Provide Temporary Tax Relief"
- BU_TaxRelief_expl: "\nProvide 3 years of tax relief to all subjects from State taxes, collecting no taxes and providing financial relief for poor families"
+ BU_TaxRelief_expl: "\nProvide 3 years of tax relief to all subjects from State taxes, collecting no taxes and providing financial relief for poor families. \nEffect starts on next tax calculation."
  BU_TaxRelief: "Widespread Tax Relief"
  desc_BU_TaxRelief: "Tax collection has been suspended, providing the people with relief and the posibility of newfound prosperity."
  BU_Grain_t: "Provide Grain for the Commoners"


### PR DESCRIPTION
1. Fix 'add_reform_desire' in events/DG-04-Hussites.txt to correctly use the owner scope.
2. Optimize 3 overlooked request tendai appointment decisions in decisions/RASE-Japan.txt to use overlord = { any_subject_country } scope, rather than the costly any_known_country scope, when checking if the position is held by another country.
3. Changed Temporary Tax Relief behavior so that it will first be put into effect at the beginning of next tax calculation, and shortened the modifier's duration so that it will be applied to precisely 3 tax calculations, matching the intuition of "3 years of tax relief"
4. Changed the logic for infrastructure maintenance spending before a full budget mechanism is implemented. Now AI will only fully pay for Capitol building maintenance when it's in their capital province.