### PR TITLE
Fix_estate_window_for_smaller_resolutions

### DIFF
--- a/MEIOUandTaxes1/src/interface/countryestatesview.gfx
+++ b/MEIOUandTaxes1/src/interface/countryestatesview.gfx
@@ -163,13 +163,13 @@ spriteTypes = {
 	
 	spriteType = {
 		name = "GFX_country_estates_view_bg"
-		texturefile = "gfx//interface//country_estates_view_bg.dds"
+		texturefile = "gfx/interface/estates/country_estates_view_bg_huge.dds"
         legacy_lazy_load = no
 	}
 	
 	spriteType = {
 		name = "GFX_country_estates_view_bg_large"
-		texturefile = "gfx//interface//country_estates_view_bg_large.dds"
+		texturefile = "gfx/interface/estates/country_estates_view_bg_huge.dds"
         legacy_lazy_load = no
 	}
 


### PR DESCRIPTION
Replaces the path for the estates window files. Instead of the small ones it always loads the largest one which is the M&T default and which the UI position coordinates are based on anyways.