### PR TITLE
V3.0 industry resurrect bugfix

### DIFF
--- a/MEIOUandTaxes1/src/common/scripted_effects/SYS-Infra.txt
+++ b/MEIOUandTaxes1/src/common/scripted_effects/SYS-Infra.txt
@@ -76,6 +76,28 @@ Infra_AddPrp = {
 		]
 	}
 }
+
+Infra_AddPrpVar = {
+	hidden_effect = {
+		if = {
+			limit = {
+				NOT = { check_key = { lhs = Building_$Type$ which = $Amount$ } }
+			}
+			change_key = { lhs = Building_$Type$ which = $Amount$ }
+		}
+		change_key = { lhs = Building_$Type$Share$Broker1$ value = 0.75 }
+		change_key = { lhs = Building_$Type$Share$Broker2$ value = 0.25 }
+		[[Cap]
+		if = {
+			limit = {
+				always = $Cap$
+				check_key = { lhs = Building_$Type$ which = Building_$Type$Max }
+			}
+			set_key = { lhs = Building_$Type$ which = Building_$Type$Max }
+		}
+		]
+	}
+}
 ### Inputs
 # id = 8 = Pathing, 9 = Harbourage, 10 = Amenities, 11 = Irrigation, 14 = Garrison
 # height = Amount of Units to build

--- a/MEIOUandTaxes1/src/events/MEC-Coal.txt
+++ b/MEIOUandTaxes1/src/events/MEC-Coal.txt
@@ -61,7 +61,7 @@ province_event = {
 		}
 		owner = { add_treasury = -5 }
 		Public_AddProduce = { prod = 14 size = 5 soph = 100 wealth = 0 }
-		Infra_AddPrp = { Type=Extraction Amount=2 Cap=yes Broker1=SF Broker2=BU }
+		Infra_AddPrp = { Type=Extraction Amount=5 Cap=yes Broker1=SF Broker2=BU }
 	}
 
 	option = {

--- a/MEIOUandTaxes1/src/events/MEC-HigherEducation.txt
+++ b/MEIOUandTaxes1/src/events/MEC-HigherEducation.txt
@@ -96,7 +96,7 @@ province_event = {
 
 		hidden_effect ={
 			Public_AddProduce = { prod = 30 size = 5 soph = 100 wealth = 0 }
-			Infra_AddPrp = { Type=Academic Amount=1 Broker1=RE Broker2=CL }
+			Infra_AddPrp = { Type=Academic Amount=5 Broker1=RE Broker2=CL }
 		}
 		#log = "MEC_HigherEd:[GetYear];[This.aab.GetValue];[This.GetName];[This.Owner.GetName];[This.GetAreaName];opened Higher Learning"
 		owner = { add_treasury = -5 }

--- a/MEIOUandTaxes1/src/events/SYS-Prod.txt
+++ b/MEIOUandTaxes1/src/events/SYS-Prod.txt
@@ -1418,49 +1418,56 @@ province_event = {
 				limit = {
 					has_province_flag = ResurrectIndustry_24
 				}
-				Effect_OpenProdVar = { IndustryID=24 Soph=100 Size=Modi_Tmp1 }
+				Public_AddProduceVar = { prod=24 soph=100 size=Modi_Tmp1 wealth = 0}
+				Infra_AddPrpVar = { Type=Industrial Amount=Modi_Tmp1 Cap=yes Broker1=NO Broker2=SF }
 				clr_province_flag = ResurrectIndustry_24
 			}
 			if = {
 				limit = {
 					has_province_flag = ResurrectIndustry_25
 				}
-				Effect_OpenProdVar = { IndustryID=25 Soph=100 Size=Modi_Tmp1 }
+				Public_AddProduceVar = { prod=25 soph=100 size=Modi_Tmp1 wealth = 0}
+				Infra_AddPrpVar = { Type=Industrial Amount=Modi_Tmp1 Broker1=RE Broker2=BG }
 				clr_province_flag = ResurrectIndustry_25
 			}
 			if = {
 				limit = {
 					has_province_flag = ResurrectIndustry_26
 				}
-				Effect_OpenProdVar = { IndustryID=26 Soph=100 Size=Modi_Tmp1 }
+				Public_AddProduceVar = { prod=26 soph=100 size=Modi_Tmp1 wealth = 0}
+				Infra_AddPrpVar = { Type=Industrial Amount=Modi_Tmp1 Broker1=RE Broker2=BG }
 				clr_province_flag = ResurrectIndustry_26
 			}
 			if = {
 				limit = {
 					has_province_flag = ResurrectIndustry_27
 				}
-				Effect_OpenProdVar = { IndustryID=27 Soph=100 Size=Modi_Tmp1 }
+				Public_AddProduceVar = { prod=27 soph=100 size=Modi_Tmp1 wealth = 0}
+				Infra_AddPrpVar = { Type=Industrial Amount=Modi_Tmp1 Broker1=RE Broker2=BG }
 				clr_province_flag = ResurrectIndustry_27
 			}
 			if = {
 				limit = {
 					has_province_flag = ResurrectIndustry_29
 				}
-				Effect_OpenProdVar = { IndustryID=29 Soph=100 Size=Modi_Tmp2 }
+				Public_AddProduceVar = { prod=29 soph=100 size=Modi_Tmp2 wealth = 0}
+				Infra_AddPrpVar = { Type=Academic Amount=Modi_Tmp2 Broker1=CL Broker2=CL }
 				clr_province_flag = ResurrectIndustry_29
 			}
 			if = {
 				limit = {
 					has_province_flag = ResurrectIndustry_30
 				}
-				Effect_OpenProdVar = { IndustryID=30 Soph=100 Size=Modi_Tmp2 }
+				Public_AddProduceVar = { prod=30 soph=100 size=Modi_Tmp2 wealth = 0}
+				Infra_AddPrpVar = { Type=Academic Amount=Modi_Tmp2 Broker1=RE Broker2=CL }
 				clr_province_flag = ResurrectIndustry_30
 			}
 			if = {
 				limit = {
 					has_province_flag = ResurrectIndustry_32
 				}
-				Effect_OpenProdVar = { IndustryID=32 Soph=100 Size=Modi_Tmp3 }
+				Public_AddProduceVar = { prod=32 soph=100 size=Modi_Tmp3 wealth = 0}
+				Infra_AddPrpVar = { Type=Commercial Amount=Modi_Tmp3 Broker1=BG Broker2=RE }
 				clr_province_flag = ResurrectIndustry_32
 			}
 			set_key = { lhs = Modi_Tmp1 value = 0 }

--- a/MEIOUandTaxes1/src/events/SYS-Prod.txt
+++ b/MEIOUandTaxes1/src/events/SYS-Prod.txt
@@ -598,7 +598,7 @@ country_event = {
 				clr_province_flag = no_mines
 				
 				Public_AddProduce = { prod = 41 size = 5 soph = 100 wealth = 0 }
-				Infra_AddPrp = { Type=Extraction Amount=1 Cap=yes Broker1=SF Broker2=NO }                
+				Infra_AddPrp = { Type=Extraction Amount=5 Cap=yes Broker1=SF Broker2=NO }                
 			}
 		}
     }


### PR DESCRIPTION
Not adding infra proportions to industry opening can introduce the following scenarios:
- No industry of this type exists, therefore no ownership shares exist and the industry is dead. (Example: https://discord.com/channels/361227452795715584/750035954869469274/1527317593961271356)
- Not adding to the amount will therefore shrink the rest of the industries after the resurrection, as the next yearly tick will limit all slot sums to the total Building_$type$ var. So if its not increased, all other industries shrink